### PR TITLE
Flagged the module as deprecated, both in metadata and doc.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision History for Class::MethodMaker (versions 2)
 
 2.23	Feb ?? 2015
+        - Flagged the module as deprecated, both in doc and metadata.
         - Use strict and warnings everywhere.
         - renamed CommonMethods.pm to CommonMethods.pmt, as it's a
           template for module code. CPANTS was assuming it's a module

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -82,6 +82,7 @@ if ( $macosx ) {
 WriteMakefile1(
   MIN_PERL_VERSION => '5.006',
   META_MERGE => {
+    x_deprecated => 1,
     resources => {
       repository => 'git://github.com/renormalist/class-methodmaker.git',
     },

--- a/lib/Class/MethodMaker.pm
+++ b/lib/Class/MethodMaker.pm
@@ -31,7 +31,7 @@ __END__
 
 =head1 NAME
 
-Class::MethodMaker - Create generic methods for OO Perl
+Class::MethodMaker - Create generic methods for OO Perl [DEPRECATED]
 
 =head1 SYNOPSIS
 
@@ -41,6 +41,12 @@ Class::MethodMaker - Create generic methods for OO Perl
     ];
 
 =head1 DESCRIPTION
+
+This module is now deprecated, as there are better more module solutions
+that are actively maintained.
+A good module to consider first is L<Moo>.
+If you have more complex requirements, then have a look at L<Moose>.
+For very lightweight OO needs, you could also look at L<Class::Tiny>.
 
 This module solves the problem of having to continually write accessor
 methods for your objects that perform standard tasks.
@@ -783,6 +789,9 @@ please contact the maintainer.
 L<Class::MethodMaker::Engine>, L<Class::MethodMaker::scalar>,
 L<Class::MethodMaker::array>, L<Class::MethodMaker::hash>,
 L<Class::MethodMaker::V1Compat>
+
+Other OO modules in decreasing order of compexity:
+L<Moose>, L<Moo>, L<Class::Tiny>.
 
 =cut
 


### PR DESCRIPTION
This flags the module as being deprecated:

 * in the abstract
 * in the first paragraph of the DESCRIPTION (which is shown by MetaCPAN), with pointers to other modules
 * in the dist's metadata, with the new `x_deprecated` field

Cheers,
Neil
