### PR TITLE
Sort hash keys

### DIFF
--- a/lib/Class/MethodMaker/OptExt.pm
+++ b/lib/Class/MethodMaker/OptExt.pm
@@ -357,7 +357,7 @@ sub encode {
 
 # -------------------------------------
 
-sub option_names { grep $_ ne 'DEFAULT', keys %{OPTEXT()} }
+sub option_names { grep $_ ne 'DEFAULT', sort keys %{OPTEXT()} }
 
 sub optcode {
   my $class = shift;


### PR DESCRIPTION
When building packages (e.g. for openSUSE Linux) in disposable VMs
cmmg.pl outputs hash value content in undeterministic order
This patch fixes this by sorting hash keys

See https://reproducible-builds.org/ for why this matters.


was also filed at
https://rt.cpan.org/Public/Bug/Display.html?id=104163
and
https://rt.cpan.org/Public/Bug/Display.html?id=122339